### PR TITLE
Use configured locale instead of hardcoded value

### DIFF
--- a/assets/rss.twig
+++ b/assets/rss.twig
@@ -7,7 +7,7 @@
 {% if app.config.get('general/payoff') is defined %}
         <description>{{ app.config.get('general/payoff') }}</description>
 {% endif %}
-        <language>en-us</language>
+        <language>{{ app.config.get('general/locale')|lower }}</language>
         <generator>Bolt</generator>
 
 {% for record in records %}


### PR DESCRIPTION
The RSS channel should follow the defined site locale, rather than having a hard-coded value (especially if that hard-coded value differs from the hard-coded site default...). This change grabs the proper config value and lowercases it, as the RSS spec dictates lowercase.