### PR TITLE
added charset=utf-8 to contenttype

### DIFF
--- a/src/RssFeedController.php
+++ b/src/RssFeedController.php
@@ -147,7 +147,7 @@ class RssFeedController implements ControllerProviderInterface
         $response->setCharset('utf-8')
             ->setPublic()
             ->setSharedMaxAge(3600)
-            ->headers->set('Content-Type', 'application/rss+xml');
+            ->headers->set('Content-Type', 'application/rss+xml;charset=UTF-8');
 
         return $response;
     }


### PR DESCRIPTION
Currently the rss feed don't have the proper header for utf-8 characters resulting in broken feeds for some validators.
If you manipulate the headers and using application instead of text as contenttype property, the setCharset method by symfony will bypassed.
See: https://github.com/symfony/symfony/blob/2.0/src/Symfony/Component/HttpFoundation/Response.php#L134-L140

The result is, that the header will not send a charset anymore. To prevent this, I added the charset directly to the headers method.